### PR TITLE
Adapted Message.php for Nexmo's keyword marketing

### DIFF
--- a/src/Service/MarketingMessage
+++ b/src/Service/MarketingMessage
@@ -1,0 +1,83 @@
+<?php
+
+namespace Nexmo\Service;
+use Symfony\Component\Config\Definition\Exception\Exception;
+
+/**
+ * Class MarketingMessage
+ * @package Nexmo\Service
+ */
+class MarketingMessage extends Service
+{
+    /**
+     * @return string The short code marketing SMS endpoint.
+     */
+    public function getEndpoint()
+    {
+        return 'sc/us/marketing/json';
+    }
+
+    /**
+     * Send a marketing message from Nexmo's shared short code.
+     *
+     * @param string|int    $from           Required. Nexmo Shared Short Code, can be found on your Dashboard.
+     * @param string        $keyword        Required. The keyword you selected during Shared Short Code sign up process.
+     * @param string|int    $to             Required. Mobile number in international format.
+     *                                      Ex: 447525856424 or 00447525856424 when sending to UK.
+     * @param string        $text           Required. Body of the text message.
+     * @throws \Nexmo\Exception
+     * @return array
+     */
+    public function invoke($from = null, $keyword = null, $to = null, $text = '')
+    {
+        if(!$from) {
+            throw new Exception("\$from parameter cannot be blank");
+        }
+
+        if(!$keyword) {
+            throw new Exception("\$keyword parameter cannot be blank");
+        }
+
+        if(!$to) {
+            throw new Exception("\$to parameter cannot be blank");
+        }
+
+        if(!$text) {
+            throw new Exception("\$text parameter cannot be blank");
+        }
+
+        return $this->exec([
+            'from' => $from,
+            'keyword' => $keyword,
+            'to' => $to,
+            'text' => $text
+        ]);
+    }
+
+    protected function validateResponse(array $json)
+    {
+        if (!isset($json['message-count'])) {
+            throw new Exception('message-count property expected');
+        }
+
+        if (!isset($json['messages'])) {
+            throw new Exception('messages property expected');
+        }
+
+        foreach ($json['messages'] as $message) {
+            if (!isset($message['status'])) {
+                throw new Exception('status property expected');
+            }
+
+            if (!empty($message["error-text"])) {
+                throw new Exception("Unable to send sms message: " . $message["error-text"] . ' - status ' . $message['status']);
+            }
+
+            if ($message['status'] > 0) {
+                throw new Exception("Unable to send sms message: status " . $message['status']);
+            }
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
Created an exact copy of Message.php and modified it to use the marketing endpoint instead of the standard messaging endpoint. Tested it with a few messages and it worked just fine. The request parameters are slightly different and more restrictive when using the short code, but the responses are exactly the same as when using the standard messaging API. Because of this, hardly any modification was needed for the validateResponse function.